### PR TITLE
Sustitución de patoolib por patool + requirements.txt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,4 +10,4 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
 else
     echo "Installer supports debian and mac only."
 fi
-pip install patoolib
+pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-beautifulsoup4==4.4.1
-bs4==0.0.1
-patool==1.12
+beautifulsoup4
+bs4
+patool

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4==4.4.1
+bs4==0.0.1
+patool==1.12


### PR DESCRIPTION
El install.sh fallaba por el paquete patoolib, ya que el nombre correcto es patool. Lo he modificado para que use el archivo requirements.txt con todas las dependencias, incluyendo bs4.
